### PR TITLE
Clean up texture crash and remove star counter

### DIFF
--- a/source/core/src/main/com/csse3200/game/components/mainmenu/MainMenuDisplay.java
+++ b/source/core/src/main/com/csse3200/game/components/mainmenu/MainMenuDisplay.java
@@ -58,18 +58,6 @@ public class MainMenuDisplay extends UIComponent {
     ImageButton storyBtn = createImageButton("images/story.png", "Story"); // Using same image for story
     ImageButton rankingBtn = createImageButton("images/rank.png", "Ranking");
 
-    Image starImage = new Image(
-            ServiceLocator.getResourceService().getAsset(
-                    "images/star.png",
-                    Texture.class
-            )
-    );
-    Label starsLabel = new Label(
-            Integer.toString(ServiceLocator.getGameStateService().getStars()),
-            skin,
-            "large"
-    );
-
     float buttonWidth = 200f;
     float buttonHeight = 50f;
     float imageButtonSize = 64f;
@@ -141,13 +129,6 @@ public class MainMenuDisplay extends UIComponent {
     });
 
     table.add().expandY().row();
-
-    HorizontalGroup starGroup = new HorizontalGroup();
-    starGroup.space(5);
-    starGroup.addActor(starImage);
-    starGroup.addActor(starsLabel);
-    table.add(starGroup);
-    table.row();
 
     table.add(startBtn).size(buttonWidth, buttonHeight).padTop(50f);
     table.row();

--- a/source/core/src/main/com/csse3200/game/screens/MainGameScreen.java
+++ b/source/core/src/main/com/csse3200/game/screens/MainGameScreen.java
@@ -58,7 +58,6 @@ public class MainGameScreen extends ScreenAdapter {
           "images/basement.png",
           "images/Background4.png",
           "images/Craft.png",
-          "images/re.gif",
           "images/main_game_background.png"
   };
 


### PR DESCRIPTION
# Description

Fixes a crash in MainGameScreen and removes the counter from the main menu

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This change was manually tested by verifying that the crash no longer occurs, and that the counter is removed from the main menu.

# Checklist:

- [x] My code follows the style guidelines of this project

- [x] I have performed a self-review of my code

- [x] My changes generate no new warnings

- [x] New and existing unit tests pass locally with my changes

- [x] Any dependent changes have been merged and published in downstream modules
