### PR TITLE
Remove creating new game state on new game

### DIFF
--- a/source/core/src/main/com/csse3200/game/components/mainmenu/MainMenuDisplay.java
+++ b/source/core/src/main/com/csse3200/game/components/mainmenu/MainMenuDisplay.java
@@ -71,7 +71,6 @@ public class MainMenuDisplay extends UIComponent {
               @Override
               public void changed(ChangeEvent changeEvent, Actor actor) {
                 logger.debug("Start button clicked");
-                ServiceLocator.registerGameStateService(new GameStateService());
                 entity.getEvents().trigger("start");
               }
             });


### PR DESCRIPTION
# Description

Remove creating a new game state in order to preserve unlocks after completing a level

Fixes / Closes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manually tested by running through a game round and checking that earned cores persist

# Checklist:

- [x] My code follows the style guidelines of this project

- [x] I have performed a self-review of my code

- [x] My changes generate no new warnings

- [x] New and existing unit tests pass locally with my changes

- [x] Any dependent changes have been merged and published in downstream modules
